### PR TITLE
Refactor article payment logic

### DIFF
--- a/desktopLive/src/Controller/ClientController.php
+++ b/desktopLive/src/Controller/ClientController.php
@@ -23,16 +23,54 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 class ClientController extends AbstractController
 {
     #[Route('/client/rate-product/{id}', name: 'app_client_rate_product', methods: ['POST'])]
-    public function rateProduct(Request $request, $id): Response
-    {
+    public function rateProduct(
+        Request $request,
+        int $id,
+        \Doctrine\ORM\EntityManagerInterface $em,
+        \App\Repository\ItemRepository $itemRepo,
+        \App\Repository\UsersRepository $usersRepo,
+        \App\Repository\RatingRepository $ratingRepo
+    ): Response {
         $session = $request->getSession();
-        $ratings = $session->get('ratings', []);
-        $rating = (int)$request->request->get('rating', 0);
-        if ($rating >= 1 && $rating <= 5) {
-            $ratings[$id] = $rating;
-            $session->set('ratings', $ratings);
+        $userSession = $session->get('user');
+        if (!$userSession) {
+            return $this->json(['success' => false, 'message' => 'Non connecté'], 401);
         }
-        return $this->redirectToRoute('app_home');
+
+        $user = $usersRepo->find($userSession->getId());
+        if (!$user) {
+            return $this->json(['success' => false, 'message' => 'Utilisateur introuvable'], 404);
+        }
+
+        $item = $itemRepo->find($id);
+        if (!$item) {
+            return $this->json(['success' => false, 'message' => 'Article introuvable'], 404);
+        }
+
+        $value = (int) $request->request->get('rating', 0);
+        if ($value < 1 || $value > 5) {
+            return $this->json(['success' => false, 'message' => 'Note invalide'], 400);
+        }
+
+        // Upsert rating (unique user+item)
+        $existing = $ratingRepo->findOneBy(['user' => $user, 'item' => $item]);
+        if ($existing) {
+            $existing->setValue($value);
+            $existing->setUpdatedAt(new \DateTimeImmutable());
+            $em->persist($existing);
+        } else {
+            $rating = new \App\Entity\Rating();
+            $rating->setUser($user)->setItem($item)->setValue($value);
+            $em->persist($rating);
+        }
+        $em->flush();
+
+        $stats = $ratingRepo->getAvgAndCountForItem($item);
+        return $this->json([
+            'success' => true,
+            'avg' => $stats['avg'],
+            'count' => $stats['count'],
+        ]);
     }
     #[Route('/client/checkout', name: 'app_client_checkout')]
     public function checkout(Request $request): Response

--- a/desktopLive/src/Controller/ClientController.php
+++ b/desktopLive/src/Controller/ClientController.php
@@ -60,6 +60,50 @@ class ClientController extends AbstractController
         $session->set('cart', array_values($cart));
         return $this->redirectToRoute('app_client_panier');
     }
+
+    #[Route('/client/cart/confirm', name: 'app_client_cart_confirm', methods: ['POST'])]
+    public function confirmCartSelection(Request $request): JsonResponse
+    {
+        $session = $request->getSession();
+        $userSession = $session->get('user');
+        if (!$userSession) {
+            return $this->json(['success' => false, 'message' => 'Non connecté'], 401);
+        }
+
+        $idsJson = (string) ($request->request->get('ids') ?? '[]');
+        $method = (string) ($request->request->get('payment_method') ?? 'mvola');
+        $ids = [];
+        try { $ids = json_decode($idsJson, true, flags: JSON_THROW_ON_ERROR); } catch (\Throwable $e) { $ids = []; }
+        if (!is_array($ids) || count($ids) === 0) {
+            return $this->json(['success' => false, 'message' => 'Aucun article sélectionné'], 400);
+        }
+
+        $cart = $session->get('cart', []);
+        $confirmedCount = 0;
+        $confirmedTotal = 0.0;
+        foreach ($cart as &$item) {
+            $id = $item['id'] ?? null;
+            if ($id !== null && in_array((string)$id, array_map('strval', $ids), true)) {
+                if (!isset($item['confirmed']) || $item['confirmed'] !== true) {
+                    $item['confirmed'] = true;
+                    $qty = (int)($item['quantity'] ?? 1);
+                    $price = (float)($item['price'] ?? 0);
+                    $confirmedCount += 1;
+                    $confirmedTotal += $qty * $price;
+                }
+            }
+        }
+        unset($item);
+        $session->set('cart', $cart);
+
+        // Note: la validation de paiement réelle sera traitée via un provider externe plus tard
+        return $this->json([
+            'success' => true,
+            'confirmed' => $confirmedCount,
+            'total' => $confirmedTotal,
+            'payment_method' => $method,
+        ]);
+    }
     #[Route('/client/add-cart/{id}', name: 'app_client_add_cart', methods: ['POST'])]
     public function addCart(Request $request, $id, \App\Repository\ItemRepository $itemRepository, \App\Repository\PriceItemsRepository $priceItemsRepository): Response
     {

--- a/desktopLive/src/Controller/HomeController.php
+++ b/desktopLive/src/Controller/HomeController.php
@@ -61,6 +61,19 @@ class HomeController extends AbstractController
                 ];
             }
 
+            // Rating moyen et nombre
+            $ratingRepo = $em->getRepository(\App\Entity\Rating::class);
+            $avg = null; $count = 0;
+            if ($ratingRepo) {
+                $stats = $em->getRepository(\App\Entity\Rating::class)->createQueryBuilder('r')
+                    ->select('AVG(r.value) AS avg_rating, COUNT(r.id) AS cnt')
+                    ->andWhere('r.item = :item')
+                    ->setParameter('item', $item)
+                    ->getQuery()->getOneOrNullResult();
+                $avg = $stats && $stats['avg_rating'] !== null ? (float)$stats['avg_rating'] : null;
+                $count = $stats ? (int)$stats['cnt'] : 0;
+            }
+
             $sellerName = $item->getSeller() ? $item->getSeller()->getUsername() : 'N/A';
             $products[] = [
                 'id' => $item->getId(),
@@ -69,7 +82,10 @@ class HomeController extends AbstractController
                 'price' => $price,
                 'sizes' => $sizes,
                 'description' => $item->getDescription() ?: 'Pas de description disponible',
-                'seller' => $sellerName
+                'seller' => $sellerName,
+                'rating' => $avg ? round($avg) : 0,
+                'ratingAvg' => $avg,
+                'ratingCount' => $count,
             ];
         }
 

--- a/desktopLive/src/Entity/Rating.php
+++ b/desktopLive/src/Entity/Rating.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\RatingRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: RatingRepository::class)]
+#[ORM\Table(name: 'rating')]
+#[ORM\UniqueConstraint(name: 'uniq_user_item', columns: ['id_user', 'id_item'])]
+class Rating
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(name: 'id_rating')]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Users::class)]
+    #[ORM\JoinColumn(name: 'id_user', referencedColumnName: 'id_user', nullable: false, onDelete: 'CASCADE')]
+    private ?Users $user = null;
+
+    #[ORM\ManyToOne(targetEntity: Item::class)]
+    #[ORM\JoinColumn(name: 'id_item', referencedColumnName: 'id_item', nullable: false, onDelete: 'CASCADE')]
+    private ?Item $item = null;
+
+    #[ORM\Column(name: 'value', type: 'integer')]
+    private int $value = 0;
+
+    #[ORM\Column(name: 'created_at', type: 'datetime')]
+    private \DateTimeInterface $createdAt;
+
+    #[ORM\Column(name: 'updated_at', type: 'datetime')]
+    private \DateTimeInterface $updatedAt;
+
+    public function __construct()
+    {
+        $now = new \DateTimeImmutable();
+        $this->createdAt = $now;
+        $this->updatedAt = $now;
+    }
+
+    public function getId(): ?int { return $this->id; }
+
+    public function getUser(): ?Users { return $this->user; }
+    public function setUser(Users $user): static { $this->user = $user; return $this; }
+
+    public function getItem(): ?Item { return $this->item; }
+    public function setItem(Item $item): static { $this->item = $item; return $this; }
+
+    public function getValue(): int { return $this->value; }
+    public function setValue(int $value): static { $this->value = $value; return $this; }
+
+    public function getCreatedAt(): \DateTimeInterface { return $this->createdAt; }
+    public function setCreatedAt(\DateTimeInterface $createdAt): static { $this->createdAt = $createdAt; return $this; }
+
+    public function getUpdatedAt(): \DateTimeInterface { return $this->updatedAt; }
+    public function setUpdatedAt(\DateTimeInterface $updatedAt): static { $this->updatedAt = $updatedAt; return $this; }
+}

--- a/desktopLive/src/Repository/RatingRepository.php
+++ b/desktopLive/src/Repository/RatingRepository.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Rating;
+use App\Entity\Item;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Rating>
+ */
+class RatingRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Rating::class);
+    }
+
+    /**
+     * @return array{avg: float|null, count: int}
+     */
+    public function getAvgAndCountForItem(Item $item): array
+    {
+        $qb = $this->createQueryBuilder('r')
+            ->select('AVG(r.value) AS avg_rating, COUNT(r.id) AS cnt')
+            ->andWhere('r.item = :item')
+            ->setParameter('item', $item);
+
+        $res = $qb->getQuery()->getOneOrNullResult();
+        $avg = $res && $res['avg_rating'] !== null ? (float)$res['avg_rating'] : null;
+        $cnt = $res ? (int)$res['cnt'] : 0;
+        return ['avg' => $avg, 'count' => $cnt];
+    }
+}

--- a/desktopLive/templates/client/checkout.html.twig
+++ b/desktopLive/templates/client/checkout.html.twig
@@ -1,35 +1,105 @@
 {% include 'components/navbarClient.html.twig' %}
 
-{% block title %}Confirmation de commande{% endblock %}
-
 {% block content %}
-<div class="container" style="margin-top:80px; max-width:900px;">
-    <h1 style="font-size:2rem; font-weight:700; margin-bottom:2rem;">Merci pour votre commande !</h1>
-    <p style="font-size:1.1rem; color:#10B981; margin-bottom:2rem;">Votre commande a bien été enregistrée.</p>
-    <h2 style="font-size:1.3rem; font-weight:600; margin-bottom:1rem;">Récapitulatif :</h2>
-    <table class="table" style="width:100%; background:#fff; border-radius:12px; box-shadow:0 2px 8px #eee;">
-        <thead>
-            <tr>
-                <th>Produit</th>
-                <th>Prix</th>
-                <th>Quantité</th>
-                <th>Total</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for item in cart %}
-            <tr>
-                <td>{{ item.name }}</td>
-                <td>{{ item.price|number_format(2, '.', ' ') }} €</td>
-                <td>{{ item.quantity }}</td>
-                <td>{{ (item.price * item.quantity)|number_format(2, '.', ' ') }} €</td>
-            </tr>
-            {% endfor %}
-        </tbody>
-    </table>
-    <div style="text-align:right; margin-top:2rem;">
-        <span style="font-size:1.2rem; font-weight:700;">Total : {{ cartTotal|number_format(2, '.', ' ') }} €</span>
+<div class="checkout-container" style="max-width:1200px;margin:90px auto 40px;padding:0 20px;">
+  <div class="checkout-grid" style="display:grid;grid-template-columns:1fr 380px;gap:24px;align-items:start;">
+    <div class="checkout-left" style="background:#fff;border-radius:12px;box-shadow:0 10px 20px rgba(0,0,0,.06);">
+      <div style="padding:20px 24px;border-bottom:1px solid #eee;display:flex;align-items:center;justify-content:space-between;">
+        <h1 style="margin:0;font-size:22px;display:flex;align-items:center;gap:10px;">
+          <i class="fa-solid fa-lock" style="color:#16a34a;"></i>
+          Récapitulatif de commande
+        </h1>
+        <a href="{{ path('app_client_panier') }}" style="text-decoration:none;color:#2563eb;font-weight:600;">Modifier le panier</a>
+      </div>
+      <div style="padding:16px 24px;">
+        {% if cart|length == 0 %}
+          <p>Votre panier est vide.</p>
+        {% else %}
+          <table style="width:100%;border-collapse:collapse;">
+            <thead>
+              <tr>
+                <th style="text-align:left;padding:10px;border-bottom:1px solid #eee;">Article</th>
+                <th style="text-align:right;padding:10px;border-bottom:1px solid #eee;">Quantité</th>
+                <th style="text-align:right;padding:10px;border-bottom:1px solid #eee;">Prix</th>
+                <th style="text-align:right;padding:10px;border-bottom:1px solid #eee;">Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for item in cart %}
+                <tr>
+                  <td style="padding:12px 10px;">{{ item.name }}</td>
+                  <td style="padding:12px 10px;text-align:right;">{{ item.quantity }}</td>
+                  <td style="padding:12px 10px;text-align:right;">{{ item.price|number_format(2, '.', ' ') }} €</td>
+                  <td style="padding:12px 10px;text-align:right;font-weight:600;">{{ (item.price * item.quantity)|number_format(2, '.', ' ') }} €</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        {% endif %}
+      </div>
     </div>
-    <a href="{{ path('app_home') }}" class="btn btn-primary" style="margin-top:2rem;">Retour à l'accueil</a>
+
+    <div class="checkout-right" style="position:relative;">
+      <div style="background:#0f172a;color:#e2e8f0;border-radius:12px;padding:18px 20px;box-shadow:0 10px 25px rgba(2,6,23,.3);">
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px;">
+          <h3 style="margin:0;font-size:18px;display:flex;align-items:center;gap:8px;color:#f8fafc;">
+            <i class="fa-solid fa-credit-card" style="color:#f59e0b;"></i>
+            Paiement sécurisé
+          </h3>
+          <span style="background:#16a34a;color:#fff;border-radius:999px;padding:4px 10px;font-size:12px;display:flex;align-items:center;gap:6px;">
+            <i class="fa-solid fa-shield-halved"></i>
+            Sécurisé
+          </span>
+        </div>
+
+        <div style="margin:12px 0 16px 0;">
+          <label style="display:block;font-weight:600;margin-bottom:8px;">Moyen de paiement</label>
+          <div style="display:flex;flex-direction:column;gap:8px;">
+            <label style="display:flex;align-items:center;gap:10px;background:#111827;border:1px solid #374151;padding:12px 14px;border-radius:10px;cursor:pointer;">
+              <input type="radio" name="payment_method" value="mvola" checked>
+              <span style="font-weight:600;color:#f9fafb;">Mvola</span>
+              <span style="color:#9ca3af;font-size:12px;">Paiement mobile</span>
+            </label>
+            <label style="display:flex;align-items:center;gap:10px;background:#111827;border:1px solid #374151;padding:12px 14px;border-radius:10px;cursor:pointer;">
+              <input type="radio" name="payment_method" value="orange">
+              <span style="font-weight:600;color:#f9fafb;">Orange Money</span>
+              <span style="color:#9ca3af;font-size:12px;">Paiement mobile</span>
+            </label>
+            <label style="display:flex;align-items:center;gap:10px;background:#111827;border:1px solid #374151;padding:12px 14px;border-radius:10px;cursor:pointer;">
+              <input type="radio" name="payment_method" value="cod">
+              <span style="font-weight:600;color:#f9fafb;">Paiement à la livraison</span>
+              <span style="color:#9ca3af;font-size:12px;">Encaissement par le livreur</span>
+            </label>
+          </div>
+        </div>
+
+        <div style="border-top:1px solid #374151;margin:12px 0;padding-top:12px;">
+          <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px;">
+            <span>Sous-total</span>
+            <span>{{ cartTotal|number_format(2, '.', ' ') }} €</span>
+          </div>
+          <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px;">
+            <span>Livraison</span>
+            <span>Gratuit</span>
+          </div>
+          <div style="display:flex;align-items:center;justify-content:space-between;font-weight:700;color:#f8fafc;">
+            <span>Total</span>
+            <span>{{ cartTotal|number_format(2, '.', ' ') }} €</span>
+          </div>
+        </div>
+
+        <div style="margin-top:14px;display:flex;flex-direction:column;gap:10px;">
+          <button type="button" style="width:100%;background:linear-gradient(135deg,#22c55e,#16a34a);color:#fff;border:none;padding:14px;border-radius:10px;font-weight:800;display:flex;align-items:center;justify-content:center;gap:8px;cursor:pointer;">
+            <i class="fa-solid fa-lock"></i>
+            Confirmer et payer {{ cartTotal|number_format(2, '.', ' ') }} €
+          </button>
+          <small style="color:#9ca3af;display:flex;align-items:center;gap:6px;">
+            <i class="fa-solid fa-info-circle"></i>
+            Le paiement sera traité de manière sécurisée. (Intégration à venir)
+          </small>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 {% endblock %}

--- a/desktopLive/templates/client/panier.html.twig
+++ b/desktopLive/templates/client/panier.html.twig
@@ -32,8 +32,21 @@
             </div>
 
             <div class="cart-items">
+                <div class="selection-bar">
+                    <label class="select-all">
+                        <input type="checkbox" id="selectAll">
+                        Tout sélectionner
+                    </label>
+                    <div class="selection-summary">
+                        <span>Sélectionnés: <strong id="selectedCount">0</strong></span>
+                        <span>Total: <strong id="selectedTotal">0,00 €</strong></span>
+                    </div>
+                </div>
                 {% for item in cart %}
-                <div class="cart-item" data-item-id="{{ item.id }}">
+                <div class="cart-item" data-item-id="{{ item.id }}" data-price="{{ item.price }}" data-quantity="{{ item.quantity }}" data-confirmed="{{ item.confirmed ? '1' : '0' }}">
+                    <div class="select-checkbox">
+                        <input type="checkbox" class="select-item" data-id="{{ item.id }}" {% if item.confirmed %}disabled{% endif %}>
+                    </div>
                     <div class="item-image">
                         {% if item.images %}
                             <img src="/uploads/{{ item.images }}" alt="{{ item.name }}" class="product-image" loading="lazy">
@@ -49,6 +62,9 @@
                             <h3 class="item-name">{{ item.name }}</h3>
                             <p class="item-price-unit">{{ item.price|number_format(2, '.', ' ') }} €/unité</p>
                         </div>
+                        {% if item.confirmed %}
+                        <span class="badge-confirmed"><i class="fa-solid fa-check"></i> Confirmé</span>
+                        {% endif %}
                         
                         <div class="item-controls">
                             <div class="quantity-controls">
@@ -95,12 +111,62 @@
             </div>
         </div>
 
-        {# Sidebar paiement -> redirection vers Checkout #}
+        {# Paiement/Validation de sélection dans le panier #}
         <div class="cart-right">
-            <a href="{{ path('app_client_checkout') }}" class="toggle-sidebar">
-                <i class="fa-solid fa-credit-card"></i>
-                Procéder au paiement
-            </a>
+            <div class="payment-card">
+                <div class="payment-header">
+                    <h3>
+                        <i class="fa-solid fa-credit-card"></i>
+                        Régler la sélection
+                    </h3>
+                    <div class="secure-badge">
+                        <i class="fa-solid fa-lock"></i>
+                        Sécurisé
+                    </div>
+                </div>
+
+                <div class="payment-form">
+                    <div class="form-section">
+                        <label class="section-label">Moyen de paiement</label>
+                        <div class="payment-methods">
+                            <label class="method-card">
+                                <input type="radio" name="payment_method" value="mvola" checked>
+                                <div class="method-icon mvola"><i class="fa-solid fa-mobile-screen"></i></div>
+                                <div class="method-info">
+                                    <span class="method-name">Mvola</span>
+                                    <span class="method-desc">Paiement mobile</span>
+                                </div>
+                            </label>
+                            <label class="method-card">
+                                <input type="radio" name="payment_method" value="orange">
+                                <div class="method-icon orange"><i class="fa-solid fa-mobile-screen"></i></div>
+                                <div class="method-info">
+                                    <span class="method-name">Orange Money</span>
+                                    <span class="method-desc">Paiement mobile</span>
+                                </div>
+                            </label>
+                            <label class="method-card">
+                                <input type="radio" name="payment_method" value="cod">
+                                <div class="method-icon" style="background:#16a34a"><i class="fa-solid fa-truck"></i></div>
+                                <div class="method-info">
+                                    <span class="method-name">À la livraison</span>
+                                    <span class="method-desc">Encaissement par le livreur</span>
+                                </div>
+                            </label>
+                        </div>
+                    </div>
+
+                    <div class="payment-actions">
+                        <button id="confirmSelection" type="button" class="btn-payment" disabled>
+                            <i class="fa-solid fa-check"></i>
+                            Valider la sélection
+                        </button>
+                        <small class="input-hint" style="display:block;margin-top:6px;">
+                            Seuls les articles sélectionnés seront confirmés.
+                        </small>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
     {% endif %}
@@ -261,15 +327,41 @@
     padding: 0;
 }
 
+/* ===== SÉLECTION D'ARTICLES ===== */
+.selection-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--gray-light);
+    background: #fafafa;
+}
+.select-all {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: 600;
+}
+.selection-summary {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    color: var(--dark);
+}
+
 .cart-item {
     display: grid;
-    grid-template-columns: 100px 1fr auto;
+    grid-template-columns: 28px 100px 1fr auto;
     gap: 20px;
     padding: 1.5rem 2rem;
     border-bottom: 1px solid var(--gray-light);
     transition: var(--transition);
     position: relative;
 }
+
+.select-checkbox { display:flex; align-items:center; justify-content:center; }
+.select-item { width: 18px; height: 18px; }
+.badge-confirmed { background:#e8f8ee; color:#15803d; border-radius:999px; padding:4px 10px; font-size:12px; font-weight:700; }
 
 .cart-item:hover {
     background: #fafafa;
@@ -514,6 +606,15 @@
     right: 20px;
 }
 
+/* Carte paiement fixe */
+.payment-card {
+    background: var(--dark);
+    color: var(--light);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow-lg);
+    padding: 1.5rem 2rem;
+}
+
 .payment-header {
     display: flex;
     justify-content: space-between;
@@ -572,7 +673,8 @@
 }
 
 .method-card {
-    display: flex;
+    display: grid;
+    grid-template-columns: 24px 40px 1fr;
     align-items: center;
     gap: 12px;
     padding: 12px 16px;
@@ -582,6 +684,7 @@
     transition: var(--transition);
     background: var(--dark-light);
 }
+.method-card input[type="radio"] { display: none; }
 
 .payment-method input[type="radio"]:checked + .method-card {
     border-color: var(--secondary);
@@ -899,7 +1002,80 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     });
     
-    // Redirection checkout: aucune logique de paiement côté panier
+    // Sélection d'articles
+    const selectAll = document.getElementById('selectAll');
+    const itemCheckboxes = Array.from(document.querySelectorAll('.select-item'));
+    const selectedCountEl = document.getElementById('selectedCount');
+    const selectedTotalEl = document.getElementById('selectedTotal');
+    const confirmBtn = document.getElementById('confirmSelection');
+
+    function computeSelection() {
+        let count = 0;
+        let total = 0;
+        itemCheckboxes.forEach(cb => {
+            if (cb.checked && !cb.disabled) {
+                count += 1;
+                const row = cb.closest('.cart-item');
+                const price = parseFloat(row.getAttribute('data-price') || '0');
+                const qty = parseInt(row.getAttribute('data-quantity') || '1');
+                total += price * qty;
+            }
+        });
+        selectedCountEl.textContent = String(count);
+        selectedTotalEl.textContent = `${total.toFixed(2)} €`;
+        confirmBtn.disabled = count === 0;
+    }
+
+    if (selectAll) {
+        selectAll.addEventListener('change', () => {
+            itemCheckboxes.forEach(cb => { if (!cb.disabled) cb.checked = selectAll.checked; });
+            computeSelection();
+        });
+    }
+
+    itemCheckboxes.forEach(cb => cb.addEventListener('change', computeSelection));
+    computeSelection();
+
+    // Validation de la sélection (confirmation côté serveur)
+    if (confirmBtn) {
+        confirmBtn.addEventListener('click', async () => {
+            const selectedIds = itemCheckboxes.filter(cb => cb.checked && !cb.disabled).map(cb => cb.getAttribute('data-id'));
+            const method = (document.querySelector('input[name="payment_method"]:checked')?.value) || 'mvola';
+            if (selectedIds.length === 0) return;
+
+            const form = new FormData();
+            form.append('ids', JSON.stringify(selectedIds));
+            form.append('payment_method', method);
+
+            try {
+                const res = await fetch('/client/cart/confirm', { method: 'POST', body: form });
+                const data = await res.json();
+                if (data && data.success) {
+                    // Marquer visuellement comme confirmé
+                    itemCheckboxes.forEach(cb => {
+                        if (cb.checked && !cb.disabled && selectedIds.includes(cb.getAttribute('data-id'))) {
+                            const row = cb.closest('.cart-item');
+                            cb.disabled = true;
+                            cb.checked = false;
+                            if (!row.querySelector('.badge-confirmed')) {
+                                const badge = document.createElement('span');
+                                badge.className = 'badge-confirmed';
+                                badge.innerHTML = '<i class="fa-solid fa-check"></i> Confirmé';
+                                row.querySelector('.item-details .item-info').after(badge);
+                            }
+                        }
+                    });
+                    computeSelection();
+                    alert('Sélection confirmée.');
+                } else {
+                    alert(data.message || 'Erreur lors de la confirmation');
+                }
+            } catch (e) {
+                console.error(e);
+                alert('Erreur réseau');
+            }
+        });
+    }
 });
 </script>
 {% endblock %}

--- a/desktopLive/templates/client/panier.html.twig
+++ b/desktopLive/templates/client/panier.html.twig
@@ -95,95 +95,12 @@
             </div>
         </div>
 
-        {# Sidebar paiement #}
+        {# Sidebar paiement -> redirection vers Checkout #}
         <div class="cart-right">
-            <button class="toggle-sidebar" id="toggleSidebar">
+            <a href="{{ path('app_client_checkout') }}" class="toggle-sidebar">
                 <i class="fa-solid fa-credit-card"></i>
-                Paiement
-            </button>
-            <div class="payment-sidebar" id="paymentSidebar">
-                <div class="payment-header">
-                    <h3>
-                        <i class="fa-solid fa-credit-card"></i>
-                        Paiement sécurisé
-                    </h3>
-                    <div class="secure-badge">
-                        <i class="fa-solid fa-lock"></i>
-                        Sécurisé
-                    </div>
-                </div>
-
-                <form id="payment-form" class="payment-form">
-                    <div class="form-section">
-                        <label class="section-label">Moyen de paiement</label>
-                        <div class="payment-methods">
-                            <div class="payment-method">
-                                <input type="radio" id="mvola" name="payment" value="mvola" checked>
-                                <label for="mvola" class="method-card">
-                                    <div class="method-icon mvola">
-                                        <i class="fa-solid fa-mobile-screen"></i>
-                                    </div>
-                                    <div class="method-info">
-                                        <span class="method-name">Mvola</span>
-                                        <span class="method-desc">Paiement mobile</span>
-                                    </div>
-                                </label>
-                            </div>
-                            <div class="payment-method">
-                                <input type="radio" id="orange" name="payment" value="orange">
-                                <label for="orange" class="method-card">
-                                    <div class="method-icon orange">
-                                        <i class="fa-solid fa-mobile-screen"></i>
-                                    </div>
-                                    <div class="method-info">
-                                        <span class="method-name">Orange Money</span>
-                                        <span class="method-desc">Paiement mobile</span>
-                                    </div>
-                                </label>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="form-section">
-                        <label for="phone" class="section-label">Numéro de téléphone</label>
-                        <div class="input-group">
-                            <span class="input-prefix">+261</span>
-                            <input type="tel" id="phone" class="form-input" 
-                                   placeholder="34 12 345 67" pattern="[0-9]{9}" required>
-                        </div>
-                    </div>
-
-                    <div class="form-section">
-                        <label for="code" class="section-label">Code de confirmation</label>
-                        <input type="text" id="code" class="form-input" 
-                               placeholder="Entrez le code reçu par SMS" required>
-                        <small class="input-hint">
-                            <i class="fa-solid fa-info-circle"></i>
-                            Un code de confirmation sera envoyé à votre numéro
-                        </small>
-                    </div>
-
-                    <div class="payment-actions">
-                        <button type="submit" class="btn-payment">
-                            <i class="fa-solid fa-lock"></i>
-                            Payer {{ cartTotal|number_format(2, '.', ' ') }} €
-                        </button>
-                        
-                        <div class="payment-security">
-                            <div class="security-features">
-                                <span class="security-item">
-                                    <i class="fa-solid fa-shield-check"></i>
-                                    Paiement 100% sécurisé
-                                </span>
-                                <span class="security-item">
-                                    <i class="fa-solid fa-rotate-left"></i>
-                                    Retour facile sous 30 jours
-                                </span>
-                            </div>
-                        </div>
-                    </div>
-                </form>
-            </div>
+                Procéder au paiement
+            </a>
         </div>
     </div>
     {% endif %}
@@ -982,100 +899,7 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     });
     
-    // Gestion de la sidebar paiement
-    const toggleSidebar = document.getElementById('toggleSidebar');
-    const paymentSidebar = document.getElementById('paymentSidebar');
-    
-    toggleSidebar.addEventListener('click', function() {
-        const isActive = paymentSidebar.classList.contains('active');
-        paymentSidebar.classList.toggle('active');
-        toggleSidebar.querySelector('i').style.transform = isActive ? 'rotate(0deg)' : 'rotate(180deg)';
-    });
-    
-    // Gestion du formulaire de paiement
-    const paymentForm = document.getElementById('payment-form');
-    if (paymentForm) {
-        paymentForm.addEventListener('submit', function(e) {
-            e.preventDefault();
-            processPayment();
-        });
-    }
-    
-    async function processPayment() {
-        const formData = new FormData(paymentForm);
-        const paymentMethod = formData.get('payment');
-        const phone = document.getElementById('phone').value;
-        const code = document.getElementById('code').value;
-        
-        if (!phone || !code) {
-            showNotification('Veuillez remplir tous les champs', 'warning');
-            return;
-        }
-        
-        try {
-            // Simulation de paiement
-            showNotification('Traitement du paiement...', 'info');
-            
-            // await fetch('/payment/process', {
-            //     method: 'POST',
-            //     headers: { 'Content-Type': 'application/json' },
-            //     body: JSON.stringify({ paymentMethod, phone, code })
-            // });
-            
-            setTimeout(() => {
-                showNotification('Paiement effectué avec succès!', 'success');
-                // Redirection vers la page de confirmation
-                // window.location.href = '/order/confirmation';
-            }, 2000);
-            
-        } catch (error) {
-            console.error('Erreur paiement:', error);
-            showNotification('Erreur lors du paiement', 'error');
-        }
-    }
-    
-    function showNotification(message, type = 'info') {
-        // Créer une notification toast
-        const notification = document.createElement('div');
-        notification.className = `notification notification-${type}`;
-        notification.innerHTML = `
-            <span>${message}</span>
-            <button onclick="this.parentElement.remove()">&times;</button>
-        `;
-        
-        // Styles pour la notification
-        notification.style.cssText = `
-            position: fixed;
-            top: 20px;
-            right: 20px;
-            padding: 12px 20px;
-            border-radius: 8px;
-            color: white;
-            font-weight: 600;
-            z-index: 1000;
-            display: flex;
-            align-items: center;
-            gap: 10px;
-            animation: slideInRight 0.3s ease-out;
-        `;
-        
-        const colors = {
-            success: '#10b981',
-            error: '#ef4444',
-            warning: '#f59e0b',
-            info: '#3b82f6'
-        };
-        
-        notification.style.background = colors[type] || colors.info;
-        
-        document.body.appendChild(notification);
-        
-        setTimeout(() => {
-            if (notification.parentElement) {
-                notification.remove();
-            }
-        }, 5000);
-    }
+    // Redirection checkout: aucune logique de paiement côté panier
 });
 </script>
 {% endblock %}

--- a/desktopLive/templates/home/index.html.twig
+++ b/desktopLive/templates/home/index.html.twig
@@ -613,12 +613,15 @@
                             {% endif %}
                         </div>
                         <div class="product-info">
-                            <div class="product-rating" style="margin-bottom:6px;">
-                                <span style="font-size:13px; color:#888; margin-left:6px;">Rating : </span>
-                                {% set rating = product.rating|default(0) %}
-                                {% for i in 1..5 %}
-                                    <i class="fa-star{% if i <= rating %} fas{% else %} far{% endif %}" style="color:#FFD600; font-size:18px;"></i>
-                                {% endfor %}
+                            <div class="product-rating" style="margin-bottom:6px; display:flex; align-items:center; gap:6px;">
+                                <span style="font-size:13px; color:#888;">Note :</span>
+                                <div class="stars" data-item-id="{{ product.id }}">
+                                    {% set rounded = product.rating|default(0) %}
+                                    {% for i in 1..5 %}
+                                        <i class="fa-star{% if i <= rounded %} fas{% else %} far{% endif %} star" data-value="{{ i }}" style="color:#FFD600; font-size:18px; cursor:pointer;"></i>
+                                    {% endfor %}
+                                </div>
+                                <span class="rating-meta" style="font-size:12px; color:#888;">({{ product.ratingAvg ? product.ratingAvg|number_format(1, '.', ' ') : '0.0' }} / 5 • {{ product.ratingCount|default(0) }})</span>
                             </div>
                             <h3 class="product-title" style="font-size:1.15rem;">{{ product.name }}</h3>
                             <div class="product-desc">{{ product.description|default('Pas de description disponible') }}</div>
@@ -701,6 +704,32 @@ document.addEventListener('DOMContentLoaded', function() {
     // --- Favoris et Panier dynamique ---
     if (productList) {
         productList.addEventListener('click', function(e) {
+            // Rating (étoiles cliquables)
+            if (e.target.classList.contains('star')) {
+                e.preventDefault();
+                const star = e.target;
+                const starsWrap = star.closest('.stars');
+                const itemId = starsWrap.getAttribute('data-item-id');
+                const value = parseInt(star.getAttribute('data-value')) || 0;
+                if (!itemId || value < 1 || value > 5) return;
+                const form = new FormData();
+                form.append('rating', String(value));
+                fetch(`/client/rate-product/${itemId}`, { method: 'POST', body: form })
+                .then(res => res.json())
+                .then(data => {
+                    if (!data.success) { alert(data.message || 'Erreur rating'); return; }
+                    // Mettre à jour les étoiles visuelles
+                    starsWrap.querySelectorAll('.star').forEach((el) => {
+                        const v = parseInt(el.getAttribute('data-value')) || 0;
+                        el.classList.toggle('fas', v <= value);
+                        el.classList.toggle('far', v > value);
+                    });
+                    const meta = starsWrap.parentElement.querySelector('.rating-meta');
+                    if (meta) meta.textContent = `(${(data.avg ?? 0).toFixed(1)} / 5 • ${data.count})`;
+                })
+                .catch(() => alert('Erreur réseau'));                
+                return;
+            }
             // Favoris
             if (e.target.closest('.fav-btn')) {
                 e.preventDefault();


### PR DESCRIPTION
Remove client-side payment simulation from the cart and introduce a dedicated checkout page to centralize payment processing.

This PR replaces the simulated payment form in `panier.html.twig` with a link to a new `checkout.html.twig` page. This new page provides an order recap and initial payment method selection (Mvola, Orange Money, COD), laying the groundwork for a more robust, server-side, and intent-based payment architecture.

---
<a href="https://cursor.com/background-agent?bcId=bc-1756e5fa-2b5d-4642-81fe-ead1d4e83155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1756e5fa-2b5d-4642-81fe-ead1d4e83155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

